### PR TITLE
correct import

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ $ pip3 install common-patterns
 ## Usage
 
 ``` python
-import common-patterns
+import common_patterns
 ```
 

--- a/common_patterns/__init__.py
+++ b/common_patterns/__init__.py
@@ -2,5 +2,3 @@
 # encoding: utf-8
 
 from .common_patterns import *
-
-name = 'common-patterns'


### PR DESCRIPTION
```
import common-patterns
  File "<stdin>", line 1
    import common-patterns
                 ^
SyntaxError: invalid syntax
>>> 
```

python imports cannot have hyphens